### PR TITLE
Adding initial TinyStrAuto

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,8 +9,12 @@ edition = "2018"
 license = "Apache-2.0/MIT"
 repository = "https://github.com/zbraniecki/tinystr"
 readme = "README.md"
-keywords = ["string", "str", "small", "tiny"]
+keywords = ["string", "str", "small", "tiny", "no_std"]
 categories = ["data-structures"]
+
+[features]
+default = [ "std" ] # Default to using the std
+std = []
 
 [dev-dependencies]
 criterion = "0.3"

--- a/benches/construct.rs
+++ b/benches/construct.rs
@@ -5,7 +5,7 @@ use criterion::Bencher;
 use criterion::Criterion;
 use criterion::Fun;
 
-use tinystr::{TinyStr16, TinyStr4, TinyStr8};
+use tinystr::{TinyStr16, TinyStr4, TinyStr8, TinyStrAuto};
 
 static STRINGS_4: &[&str] = &[
     "US", "GB", "AR", "Hans", "CN", "AT", "PL", "FR", "AT", "Cyrl", "SR", "NO", "FR", "MK", "UK",
@@ -41,6 +41,7 @@ macro_rules! bench_block {
             Fun::new("TinyStr4", $action!(TinyStr4)),
             Fun::new("TinyStr8", $action!(TinyStr8)),
             Fun::new("TinyStr16", $action!(TinyStr16)),
+            Fun::new("TinyStrAuto", $action!(TinyStrAuto)),
         ];
 
         $c.bench_functions(&format!("{}/4", $name), funcs, STRINGS_4);
@@ -49,6 +50,7 @@ macro_rules! bench_block {
             Fun::new("String", $action!(String)),
             Fun::new("TinyStr8", $action!(TinyStr8)),
             Fun::new("TinyStr16", $action!(TinyStr16)),
+            Fun::new("TinyStrAuto", $action!(TinyStrAuto)),
         ];
 
         $c.bench_functions(&format!("{}/8", $name), funcs, STRINGS_8);
@@ -56,6 +58,7 @@ macro_rules! bench_block {
         let funcs = vec![
             Fun::new("String", $action!(String)),
             Fun::new("TinyStr16", $action!(TinyStr16)),
+            Fun::new("TinyStrAuto", $action!(TinyStrAuto)),
         ];
 
         $c.bench_functions(&format!("{}/16", $name), funcs, STRINGS_16);
@@ -107,7 +110,9 @@ fn construct_from_bytes(c: &mut Criterion) {
 
     c.bench_functions("construct_from_bytes/8", funcs, STRINGS_8);
 
-    let funcs = vec![Fun::new("TinyStr16", cfu!(TinyStr16))];
+    let funcs = vec![
+        Fun::new("TinyStr16", cfu!(TinyStr16)),
+    ];
 
     c.bench_functions("construct_from_bytes/16", funcs, STRINGS_16);
 }

--- a/src/helpers.rs
+++ b/src/helpers.rs
@@ -3,6 +3,15 @@ use std::ptr::copy_nonoverlapping;
 
 use super::Error;
 
+#[cfg(any(feature = "std", test))]
+pub use std::string::String;
+
+#[cfg(all(not(feature = "std"), not(test)))]
+extern crate alloc;
+
+#[cfg(all(not(feature = "std"), not(test)))]
+pub use alloc::string::String;
+
 #[inline(always)]
 pub(crate) unsafe fn make_4byte_bytes(
     bytes: &[u8],

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -59,6 +59,4 @@ pub enum Error {
     InvalidNull,
     /// String contains non-ASCII character(s).
     NonAscii,
-    /// An error that should not occur.
-    Infallible,
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -36,17 +36,8 @@
 #[cfg(any(feature = "std", test))]
 extern crate std;
 
-#[cfg(any(feature = "std", test))]
-pub use std::string::String;
-
 #[cfg(all(not(feature = "std"), not(test)))]
 extern crate core as std;
-
-#[cfg(all(not(feature = "std"), not(test)))]
-extern crate alloc;
-
-#[cfg(all(not(feature = "std"), not(test)))]
-pub use alloc::string::String;
 
 mod helpers;
 mod tinystr16;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -36,8 +36,17 @@
 #[cfg(any(feature = "std", test))]
 extern crate std;
 
+#[cfg(any(feature = "std", test))]
+pub use std::string::String;
+
 #[cfg(all(not(feature = "std"), not(test)))]
 extern crate core as std;
+
+#[cfg(all(not(feature = "std"), not(test)))]
+extern crate alloc;
+
+#[cfg(all(not(feature = "std"), not(test)))]
+pub use alloc::string::String;
 
 mod helpers;
 mod tinystr16;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -34,10 +34,12 @@ mod helpers;
 mod tinystr16;
 mod tinystr4;
 mod tinystr8;
+mod tinystrauto;
 
 pub use tinystr16::TinyStr16;
 pub use tinystr4::TinyStr4;
 pub use tinystr8::TinyStr8;
+pub use tinystrauto::TinyStrAuto;
 
 /// Enum to store the various types of errors that can cause parsing a TinyStr to fail.
 #[derive(PartialEq, Eq, Debug)]
@@ -48,4 +50,6 @@ pub enum Error {
     InvalidNull,
     /// String contains non-ASCII character(s).
     NonAscii,
+    /// An error that should not occur.
+    Infallible,
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -30,6 +30,15 @@
 //!     assert_eq!(s2.is_ascii_alphanumeric(), false);
 //! }
 //! ```
+
+#![no_std]
+
+#[cfg(any(feature = "std", test))]
+extern crate std;
+
+#[cfg(all(not(feature = "std"), not(test)))]
+extern crate core as std;
+
 mod helpers;
 mod tinystr16;
 mod tinystr4;

--- a/src/tinystrauto.rs
+++ b/src/tinystrauto.rs
@@ -63,8 +63,7 @@ impl FromStr for TinyStrAuto {
             }
             match String::from_str(text) {
                 Ok(result) => Ok(TinyStrAuto::Long(result)),
-                // String::from_str returns a Result<String, std::convert::Infallible>
-                Err(_) => Err(Error::Infallible),
+                Err(_) => unreachable!(),
             }
         }
     }

--- a/src/tinystrauto.rs
+++ b/src/tinystrauto.rs
@@ -3,6 +3,7 @@ use std::ops::Deref;
 use std::str::FromStr;
 
 use crate::Error;
+use crate::String;
 use crate::TinyStr16;
 
 /// An ASCII string that is tiny when <= 16 chars and a String otherwise.

--- a/src/tinystrauto.rs
+++ b/src/tinystrauto.rs
@@ -1,0 +1,70 @@
+use std::fmt;
+use std::ops::Deref;
+use std::str::FromStr;
+
+use crate::Error;
+use crate::TinyStr16;
+
+/// An ASCII string that is tiny when <= 16 chars and a String otherwise.
+///
+/// # Examples
+///
+/// ```
+/// use tinystr::TinyStrAuto;
+///
+/// let s1: TinyStrAuto = "Testing".parse()
+///     .expect("Failed to parse.");
+///
+/// assert_eq!(s1, "Testing");
+/// ```
+#[derive(Clone, PartialEq, Eq, Hash, PartialOrd, Ord, Debug)]
+pub enum TinyStrAuto {
+    Tiny(TinyStr16),
+    Long(String),
+}
+
+impl fmt::Display for TinyStrAuto {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        write!(f, "{}", self.deref())
+    }
+}
+
+impl Deref for TinyStrAuto {
+    type Target = str;
+
+    fn deref(&self) -> &str {
+        use TinyStrAuto::*;
+        match self {
+            Tiny(value) => value.deref(),
+            Long(value) => value.deref(),
+        }
+    }
+}
+
+impl PartialEq<&str> for TinyStrAuto {
+    fn eq(&self, other: &&str) -> bool {
+        self.deref() == *other
+    }
+}
+
+impl FromStr for TinyStrAuto {
+    type Err = Error;
+
+    fn from_str(text: &str) -> Result<Self, Self::Err> {
+        if text.len() <= 16 {
+            match TinyStr16::from_str(text) {
+                Ok(result) => Ok(TinyStrAuto::Tiny(result)),
+                Err(err) => Err(err),
+            }
+        } else {
+            if !text.is_ascii() {
+                return Err(Error::NonAscii)
+            }
+            match String::from_str(text) {
+                Ok(result) => Ok(TinyStrAuto::Long(result)),
+                // String::from_str returns a Result<String, std::convert::Infallible>
+                Err(_) => Err(Error::Infallible),
+            }
+        }
+    }
+}

--- a/src/tinystrauto.rs
+++ b/src/tinystrauto.rs
@@ -3,8 +3,8 @@ use std::ops::Deref;
 use std::str::FromStr;
 
 use crate::Error;
-use crate::String;
 use crate::TinyStr16;
+use crate::helpers::String;
 
 /// An ASCII string that is tiny when <= 16 chars and a String otherwise.
 ///

--- a/tests/main.rs
+++ b/tests/main.rs
@@ -1,6 +1,17 @@
 use std::fmt::Write;
+use std::mem::size_of;
 use std::ops::Deref;
-use tinystr::{Error, TinyStr16, TinyStr4, TinyStr8};
+use tinystr::{Error, TinyStr16, TinyStr4, TinyStr8, TinyStrAuto};
+
+#[test]
+fn tiny_sizes() {
+    assert_eq!(4, size_of::<TinyStr4>());
+    assert_eq!(8, size_of::<TinyStr8>());
+    assert_eq!(16, size_of::<TinyStr16>());
+    assert_eq!(24, size_of::<String>());
+    // Note: TinyStrAuto is size 32 even when a smaller TinyStr type is used
+    assert_eq!(32, size_of::<TinyStrAuto>());
+}
 
 #[test]
 fn tiny4_basic() {
@@ -479,4 +490,21 @@ fn tiny16_display() {
 fn tiny16_debug() {
     let s: TinyStr16 = "abcdefghijkl".parse().unwrap();
     assert_eq!(format!("{:#?}", s), "\"abcdefghijkl\"");
+}
+
+#[test]
+fn tinyauto_basic() {
+    let s1: TinyStrAuto = "abc".parse().unwrap();
+    assert_eq!(s1, "abc");
+
+    let s2: TinyStrAuto = "veryveryveryveryverylong".parse().unwrap();
+    assert_eq!(s2, "veryveryveryveryverylong");
+}
+
+#[test]
+fn tinyauto_nonascii() {
+    assert_eq!("\u{4000}".parse::<TinyStrAuto>(), Err(Error::NonAscii));
+    assert_eq!(
+        "veryveryveryveryverylong\u{4000}".parse::<TinyStrAuto>(),
+        Err(Error::NonAscii));
 }


### PR DESCRIPTION
See #12

I didn't make it as full-featured as the other TinyStr classes, but it's a start, and we can always extend it later with more functionality.

For benchmarks, it's slower than TinyStr16 but still faster than String:

```
construct_from_str/4/String                                                                            
                        time:   [273.85 ns 274.47 ns 275.16 ns]
Found 1 outliers among 100 measurements (1.00%)
  1 (1.00%) high mild
construct_from_str/4/TinyStr4                                                                             
                        time:   [37.812 ns 38.048 ns 38.352 ns]
Found 9 outliers among 100 measurements (9.00%)
  3 (3.00%) high mild
  6 (6.00%) high severe
construct_from_str/4/TinyStr8                                                                            
                        time:   [106.20 ns 106.40 ns 106.65 ns]
Found 9 outliers among 100 measurements (9.00%)
  1 (1.00%) high mild
  8 (8.00%) high severe
construct_from_str/4/TinyStr16                                                                            
                        time:   [123.80 ns 124.23 ns 124.63 ns]
Found 2 outliers among 100 measurements (2.00%)
  2 (2.00%) high severe
construct_from_str/4/TinyStrAuto                                                                            
                        time:   [217.17 ns 217.45 ns 217.76 ns]
Found 6 outliers among 100 measurements (6.00%)
  6 (6.00%) high mild

construct_from_str/8/String                                                                            
                        time:   [274.54 ns 279.42 ns 286.65 ns]
Found 7 outliers among 100 measurements (7.00%)
  3 (3.00%) high mild
  4 (4.00%) high severe
construct_from_str/8/TinyStr8                                                                            
                        time:   [106.48 ns 106.97 ns 107.52 ns]
Found 5 outliers among 100 measurements (5.00%)
  4 (4.00%) high mild
  1 (1.00%) high severe
construct_from_str/8/TinyStr16                                                                            
                        time:   [120.44 ns 121.50 ns 122.81 ns]
Found 8 outliers among 100 measurements (8.00%)
  2 (2.00%) high mild
  6 (6.00%) high severe
construct_from_str/8/TinyStrAuto                                                                            
                        time:   [220.62 ns 222.09 ns 223.60 ns]
Found 9 outliers among 100 measurements (9.00%)
  8 (8.00%) high mild
  1 (1.00%) high severe

construct_from_str/16/String                                                                            
                        time:   [269.30 ns 270.08 ns 271.01 ns]
Found 12 outliers among 100 measurements (12.00%)
  8 (8.00%) high mild
  4 (4.00%) high severe
construct_from_str/16/TinyStr16                                                                            
                        time:   [114.27 ns 114.46 ns 114.68 ns]
Found 7 outliers among 100 measurements (7.00%)
  5 (5.00%) high mild
  2 (2.00%) high severe
construct_from_str/16/TinyStrAuto                                                                            
                        time:   [213.54 ns 214.02 ns 214.52 ns]
Found 7 outliers among 100 measurements (7.00%)
  1 (1.00%) low severe
  3 (3.00%) high mild
  3 (3.00%) high severe
```