### PR TITLE
Make tinystr no_std-compatible

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,8 +9,12 @@ edition = "2018"
 license = "Apache-2.0/MIT"
 repository = "https://github.com/zbraniecki/tinystr"
 readme = "README.md"
-keywords = ["string", "str", "small", "tiny"]
+keywords = ["string", "str", "small", "tiny", "no_std"]
 categories = ["data-structures"]
+
+[features]
+default = [ "std" ] # Default to using the std
+std = []
 
 [dev-dependencies]
 criterion = "0.3"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -30,6 +30,15 @@
 //!     assert_eq!(s2.is_ascii_alphanumeric(), false);
 //! }
 //! ```
+
+#![no_std]
+
+#[cfg(any(feature = "std", test))]
+extern crate std;
+
+#[cfg(all(not(feature = "std"), not(test)))]
+extern crate core as std;
+
 mod helpers;
 mod tinystr16;
 mod tinystr4;


### PR DESCRIPTION
Seems like it works out of the box?

Fixes #13

Note: I have an additional commit to add no_std support for #14.