### PR TITLE
Refactor TinyStr macros to be defined and exported from the main crate.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,7 +4,7 @@ description = """
 A small ASCII-only bounded length string representation.
 """
 version = "0.3.4"
-authors = ["Raph Levien <raph.levien@gmail.com>", "Zibi Braniecki <zibi@braniecki.net>"]
+authors = ["Raph Levien <raph.levien@gmail.com>", "Zibi Braniecki <zibi@braniecki.net>", "Shane F. Carr <shane@sffc.xyz>"]
 edition = "2018"
 license = "Apache-2.0/MIT"
 repository = "https://github.com/zbraniecki/tinystr"
@@ -13,8 +13,8 @@ keywords = ["string", "str", "small", "tiny", "no_std"]
 categories = ["data-structures"]
 
 [dependencies]
-tinystr-macros = { version = "0.1", path = "./macros", optional = true }
-tinystr-raw = { path = "./raw" }
+tinystr-macros = { version = "0.1", path = "./macros" }
+tinystr-raw = { version = "0.1", path = "./raw" }
 
 [dev-dependencies]
 criterion = "0.3"
@@ -27,8 +27,6 @@ std = []
 
 # Use the `alloc` crate. Enables TinyStrAuto. This feature does nothing if std is enabled.
 alloc = []
-
-macros = ["tinystr-macros"]
 
 [[bench]]
 name = "construct"

--- a/benches/tinystr.rs
+++ b/benches/tinystr.rs
@@ -96,7 +96,6 @@ fn convert_to_ascii_uppercase(c: &mut Criterion) {
 }
 
 trait ExtToAsciiTitlecase {
-    #[inline(always)]
     fn to_ascii_titlecase(&self) -> String;
 }
 
@@ -119,7 +118,6 @@ fn convert_to_ascii_titlecase(c: &mut Criterion) {
 }
 
 trait ExtIsAsciiAlphanumeric {
-    #[inline(always)]
     fn is_ascii_alphanumeric(&self) -> bool;
 }
 

--- a/macros/Cargo.toml
+++ b/macros/Cargo.toml
@@ -4,7 +4,7 @@ description = """
 Proc macros for TinyStr.
 """
 version = "0.1.0"
-authors = ["Zibi Braniecki <zibi@braniecki.net>"]
+authors = ["Zibi Braniecki <zibi@braniecki.net>", "Shane F. Carr <shane@sffc.xyz>"]
 edition = "2018"
 license = "Apache-2.0/MIT"
 repository = "https://github.com/zbraniecki/tinystr"
@@ -17,3 +17,4 @@ proc_macro = true
 
 [dependencies]
 tinystr = "0.3"
+tinystr-raw = { path = "../raw" }

--- a/macros/src/lib.rs
+++ b/macros/src/lib.rs
@@ -1,43 +1,40 @@
+//! `tinystr-macros` exports proc macros to convert byte strings to raw TinyStr data.
+//!
+//! Not intended for public consumption; use `tinystr` instead.
+
 extern crate proc_macro;
 
-use proc_macro::TokenStream;
+// use proc_macro::bridge::client::Literal as BridgeLiteral;
+use proc_macro::{Literal, TokenStream, TokenTree};
 
 fn get_value_from_token_stream(input: TokenStream) -> String {
-    let val = format!("{}", input);
-    if !val.starts_with('"') || !val.ends_with('"') {
-        panic!("Argument must be a string literal.");
+    let val = input.to_string();
+    if !val.starts_with('"') && !val.ends_with('"') {
+        panic!("Expected a string literal; found {:?}", input);
     }
-    let len = val.len();
-    (&val[1..len - 1]).to_string()
+    (&val[1..val.len() - 1]).to_string()
 }
 
 #[proc_macro]
-pub fn tinystr4(input: TokenStream) -> TokenStream {
-    let val = get_value_from_token_stream(input);
-    let bytes: u32 = tinystr::TinyStr4::from_bytes(val.as_bytes())
-        .expect("Failed to construct TinyStr from input")
-        .into();
-
-    let formula = format!("unsafe {{ tinystr::TinyStr4::new_unchecked({}) }}", bytes);
-    formula.parse().unwrap()
+pub fn u32_from_bytes(input: TokenStream) -> TokenStream {
+    let s = get_value_from_token_stream(input);
+    let u = tinystr_raw::try_u32_from_bytes(s.as_bytes())
+        .expect(&s);
+    TokenTree::from(Literal::u32_suffixed(u.into())).into()
 }
 
 #[proc_macro]
-pub fn tinystr8(input: TokenStream) -> TokenStream {
-    let val = get_value_from_token_stream(input);
-    let bytes: u64 = tinystr::TinyStr8::from_bytes(val.as_bytes())
-        .expect("Failed to construct TinyStr from input")
-        .into();
-    let formula = format!("unsafe {{ tinystr::TinyStr8::new_unchecked({}) }}", bytes);
-    formula.parse().unwrap()
+pub fn u64_from_bytes(input: TokenStream) -> TokenStream {
+    let s = get_value_from_token_stream(input);
+    let u = tinystr_raw::try_u64_from_bytes(s.as_bytes())
+        .expect("Failed to construct TinyStr from input");
+    TokenTree::from(Literal::u64_suffixed(u.into())).into()
 }
 
 #[proc_macro]
-pub fn tinystr16(input: TokenStream) -> TokenStream {
-    let val = get_value_from_token_stream(input);
-    let bytes: u128 = tinystr::TinyStr16::from_bytes(val.as_bytes())
-        .expect("Failed to construct TinyStr from input")
-        .into();
-    let formula = format!("unsafe {{ tinystr::TinyStr16::new_unchecked({}) }}", bytes);
-    formula.parse().unwrap()
+pub fn u128_from_bytes(input: TokenStream) -> TokenStream {
+    let s = get_value_from_token_stream(input);
+    let u = tinystr_raw::try_u128_from_bytes(s.as_bytes())
+        .expect("Failed to construct TinyStr from input");
+    TokenTree::from(Literal::u128_suffixed(u.into())).into()
 }

--- a/macros/tests/macros.rs
+++ b/macros/tests/macros.rs
@@ -1,19 +1,19 @@
-use tinystr::*;
 use tinystr_macros::*;
 
-const TS: TinyStr8 = tinystr8!("test");
+#[test]
+fn test_u32() {
+    const VALUE: u32 = u32_from_bytes!("aabb");
+    assert_eq!(0x62626161, VALUE);
+}
 
 #[test]
-fn test_macros() {
-    let x: TinyStr8 = "test".parse().unwrap();
-    assert_eq!(TS, x);
+fn test_u64() {
+    const VALUE: u64 = u64_from_bytes!("aaaabbbb");
+    assert_eq!(0x6262626261616161, VALUE);
+}
 
-    let x: TinyStr4 = "foo".parse().unwrap();
-    assert_eq!(tinystr4!("foo"), x);
-
-    let x: TinyStr8 = "barbaz".parse().unwrap();
-    assert_eq!(tinystr8!("barbaz"), x);
-
-    let x: TinyStr16 = "metamorphosis".parse().unwrap();
-    assert_eq!(tinystr16!("metamorphosis"), x);
+#[test]
+fn test_u128() {
+    const VALUE: u128 = u128_from_bytes!("aaaaaaaabbbbbbbb");
+    assert_eq!(0x62626262626262626161616161616161, VALUE);
 }

--- a/raw/Cargo.toml
+++ b/raw/Cargo.toml
@@ -4,7 +4,7 @@ description = """
 Raw string-to-integer conversions for tinystr.
 """
 version = "0.1.0"
-authors = ["Zibi Braniecki <zibi@braniecki.net>", "Shane Carr <shane@sffc.xyz>"]
+authors = ["Zibi Braniecki <zibi@braniecki.net>", "Shane F. Carr <shane@sffc.xyz>"]
 edition = "2018"
 license = "Apache-2.0/MIT"
 repository = "https://github.com/zbraniecki/tinystr"

--- a/raw/src/lib.rs
+++ b/raw/src/lib.rs
@@ -1,3 +1,7 @@
+//! `tinystr-raw` exports functions to convert byte strings to raw TinyStr data.
+//!
+//! Not intended for public consumption; use `tinystr` instead.
+
 mod error;
 mod helpers;
 
@@ -6,7 +10,7 @@ pub use error::Error;
 use std::num::{NonZeroU32, NonZeroU64, NonZeroU128};
 
 #[inline(always)]
-pub fn u32_from_bytes(bytes: &[u8]) -> Result<NonZeroU32, Error> {
+pub fn try_u32_from_bytes(bytes: &[u8]) -> Result<NonZeroU32, Error> {
     unsafe {
         match bytes.len() {
             1 => helpers::make_u32_bytes(bytes, 1, 0x80),
@@ -27,7 +31,7 @@ fn test_u32_from_bytes() {
 }
 
 #[inline(always)]
-pub fn u64_from_bytes(bytes: &[u8]) -> Result<NonZeroU64, Error> {
+pub fn try_u64_from_bytes(bytes: &[u8]) -> Result<NonZeroU64, Error> {
     let len = bytes.len();
     if len < 1 || len > 8 {
         return Err(Error::InvalidSize);
@@ -47,7 +51,7 @@ fn test_u64_from_bytes() {
 }
 
 #[inline(always)]
-pub fn u128_from_bytes(bytes: &[u8]) -> Result<NonZeroU128, Error> {
+pub fn try_u128_from_bytes(bytes: &[u8]) -> Result<NonZeroU128, Error> {
     let len = bytes.len();
     if len < 1 || len > 16 {
         return Err(Error::InvalidSize);

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -5,7 +5,7 @@
 //!
 //! `tinystr` converts each string into an unsigned integer, and uses bitmasking
 //! to compare, convert cases and test for common characteristics of strings.
-//! 
+//!
 //! # Details
 //!
 //! The crate provides three structs and an enum:
@@ -21,6 +21,13 @@
 //! or smaller, but occasionally you receive one that exceeds that length. Unlike the structs,
 //! `TinyStrAuto` does not implement `Copy`.
 //!
+//! # Macros
+//!
+//! Compile-time macros are available to convert string literals into const TinyStrs:
+//! * `tinystr4!("abc")`
+//! * `tinystr8!("abcdefg")`
+//! * `tinystr16!("longer-string")`
+//!
 //! # no_std
 //!
 //! Disable the `std` feature of this crate to make it `#[no_std]`. Doing so disables `TinyStrAuto`.
@@ -30,9 +37,9 @@
 //!
 //! ```
 //! use tinystr::{TinyStr4, TinyStr8, TinyStr16, TinyStrAuto};
+//! use tinystr::{tinystr4, tinystr8, tinystr16};
 //!
-//! let s1: TinyStr4 = "tEsT".parse()
-//!     .expect("Failed to parse.");
+//! let s1: TinyStr4 = tinystr4!("tEsT");
 //!
 //! assert_eq!(s1, "tEsT");
 //! assert_eq!(s1.to_ascii_uppercase(), "TEST");
@@ -40,8 +47,7 @@
 //! assert_eq!(s1.to_ascii_titlecase(), "Test");
 //! assert_eq!(s1.is_ascii_alphanumeric(), true);
 //!
-//! let s2: TinyStr8 = "New York".parse()
-//!      .expect("Failed to parse.");
+//! let s2: TinyStr8 = tinystr8!("New York");
 //!
 //! assert_eq!(s2, "New York");
 //! assert_eq!(s2.to_ascii_uppercase(), "NEW YORK");
@@ -49,8 +55,7 @@
 //! assert_eq!(s2.to_ascii_titlecase(), "New york");
 //! assert_eq!(s2.is_ascii_alphanumeric(), false);
 //!
-//! let s3: TinyStr16 = "metaMoRphosis123".parse()
-//!     .expect("Failed to parse.");
+//! let s3: TinyStr16 = tinystr16!("metaMoRphosis123");
 //!
 //! assert_eq!(s3, "metaMoRphosis123");
 //! assert_eq!(s3.to_ascii_uppercase(), "METAMORPHOSIS123");
@@ -58,11 +63,13 @@
 //! assert_eq!(s3.to_ascii_titlecase(), "Metamorphosis123");
 //! assert_eq!(s3.is_ascii_alphanumeric(), true);
 //!
-//! let s4: TinyStrAuto = "shortNoAlloc".parse().unwrap();
+//! let s4: TinyStrAuto = "shortNoAlloc".parse()
+//!     .expect("Failed to parse.");
 //! assert!(matches!(s4, TinyStrAuto::Tiny { .. }));
 //! assert_eq!(s4, "shortNoAlloc");
 //!
-//! let s5: TinyStrAuto = "longFallbackToHeap".parse().unwrap();
+//! let s5: TinyStrAuto = "longFallbackToHeap".parse()
+//!     .expect("Failed to parse.");
 //! assert!(matches!(s5, TinyStrAuto::Heap { .. }));
 //! assert_eq!(s5, "longFallbackToHeap");
 //! ```
@@ -75,6 +82,7 @@ extern crate std;
 #[cfg(all(not(feature = "std"), not(test)))]
 extern crate core as std;
 
+mod macros;
 mod tinystr16;
 mod tinystr4;
 mod tinystr8;

--- a/src/macros.rs
+++ b/src/macros.rs
@@ -1,0 +1,86 @@
+/// Macro to create a const TinyStr4, validated with zero runtime cost.
+///
+/// The argument must be a string literal:
+/// https://doc.rust-lang.org/reference/tokens.html#string-literals
+///
+/// # Example
+///
+/// ```
+/// use tinystr::{tinystr4, TinyStr4};
+///
+/// const S1: TinyStr4 = tinystr4!("abc");
+/// let s2: TinyStr4 = "abc".parse().unwrap();
+/// assert_eq!(S1, s2);
+/// ```
+#[macro_export]
+macro_rules! tinystr4 {
+    ($s:literal) => {
+        unsafe { $crate::TinyStr4::new_unchecked(tinystr_macros::u32_from_bytes!($s)) }
+    };
+}
+
+#[test]
+fn test_tinystr4() {
+    use crate::TinyStr4;
+    const X1: TinyStr4 = tinystr4!("foo");
+    let x2: TinyStr4 = "foo".parse().unwrap();
+    assert_eq!(X1, x2);
+}
+
+/// Macro to create a const TinyStr8, validated with zero runtime cost.
+///
+/// The argument must be a string literal:
+/// https://doc.rust-lang.org/reference/tokens.html#string-literals
+///
+/// # Example
+///
+/// ```
+/// use tinystr::{tinystr8, TinyStr8};
+///
+/// const S1: TinyStr8 = tinystr8!("abcdefg");
+/// let s2: TinyStr8 = "abcdefg".parse().unwrap();
+/// assert_eq!(S1, s2);
+/// ```
+#[macro_export]
+macro_rules! tinystr8 {
+    ($s:literal) => {
+        unsafe { $crate::TinyStr8::new_unchecked(tinystr_macros::u64_from_bytes!($s)) }
+    };
+}
+
+#[test]
+fn test_tinystr8() {
+    use crate::TinyStr8;
+    const X1: TinyStr8 = tinystr8!("barbaz");
+    let x2: TinyStr8 = "barbaz".parse().unwrap();
+    assert_eq!(X1, x2);
+}
+
+/// Macro to create a const TinyStr8, validated with zero runtime cost.
+///
+/// The argument must be a string literal:
+/// https://doc.rust-lang.org/reference/tokens.html#string-literals
+///
+/// # Example
+///
+/// ```
+/// use tinystr::{tinystr16, TinyStr16};
+///
+/// const S1: TinyStr16 = tinystr16!("longer-string");
+/// let s2: TinyStr16 = "longer-string".parse().unwrap();
+/// assert_eq!(S1, s2);
+/// ```
+#[macro_export]
+macro_rules! tinystr16 {
+    ($s:literal) => {
+        unsafe { $crate::TinyStr16::new_unchecked(tinystr_macros::u128_from_bytes!($s)) }
+    };
+}
+
+#[test]
+fn test_tinystr16() {
+    use crate::TinyStr16;
+    const X1: TinyStr16 = tinystr16!("metamorphosis");
+    let x2: TinyStr16 = "metamorphosis".parse().unwrap();
+    assert_eq!(X1, x2);
+}

--- a/src/tinystr16.rs
+++ b/src/tinystr16.rs
@@ -38,7 +38,7 @@ impl TinyStr16 {
     /// ```
     #[inline(always)]
     pub fn from_bytes(bytes: &[u8]) -> Result<Self, Error> {
-        tinystr_raw::u128_from_bytes(bytes).map(Self)
+        tinystr_raw::try_u128_from_bytes(bytes).map(Self)
     }
 
     /// An unsafe constructor intended for cases where the consumer

--- a/src/tinystr4.rs
+++ b/src/tinystr4.rs
@@ -38,7 +38,7 @@ impl TinyStr4 {
     /// ```
     #[inline(always)]
     pub fn from_bytes(bytes: &[u8]) -> Result<Self, Error> {
-        tinystr_raw::u32_from_bytes(bytes).map(Self)
+        tinystr_raw::try_u32_from_bytes(bytes).map(Self)
     }
 
     /// An unsafe constructor intended for cases where the consumer

--- a/src/tinystr8.rs
+++ b/src/tinystr8.rs
@@ -38,7 +38,7 @@ impl TinyStr8 {
     /// ```
     #[inline(always)]
     pub fn from_bytes(bytes: &[u8]) -> Result<Self, Error> {
-        tinystr_raw::u64_from_bytes(bytes).map(Self)
+        tinystr_raw::try_u64_from_bytes(bytes).map(Self)
     }
 
     /// An unsafe constructor intended for cases where the consumer

--- a/tests/main.rs
+++ b/tests/main.rs
@@ -25,7 +25,7 @@ fn tiny4_basic() {
 
 #[test]
 fn tiny4_from_bytes() {
-    let s = TinyStr4::from_bytes("abc".as_bytes()).unwrap();
+    let s = TinyStr4::from_bytes(b"abc").unwrap();
     assert_eq!(s.deref(), "abc");
 
     assert_eq!(
@@ -174,7 +174,7 @@ fn tiny8_basic() {
 
 #[test]
 fn tiny8_from_bytes() {
-    let s = TinyStr8::from_bytes("abcde".as_bytes()).unwrap();
+    let s = TinyStr8::from_bytes(b"abcde").unwrap();
     assert_eq!(s.deref(), "abcde");
 
     assert_eq!(
@@ -326,7 +326,7 @@ fn tiny8_debug() {
 
 #[test]
 fn tiny16_from_bytes() {
-    let s = TinyStr16::from_bytes("abcdefghijk".as_bytes()).unwrap();
+    let s = TinyStr16::from_bytes(b"abcdefghijk").unwrap();
     assert_eq!(s.deref(), "abcdefghijk");
 
     assert_eq!(


### PR DESCRIPTION
I decided to keep the macros as requiring string literals `"..."`.  I've learned that the Rust compiler tokenizes the source text before passing it into the proc macro, so it's not semantically correct for us to accept a token tree (`tt`) or identifier (`ident`), since the grammar for those tokens does not cover the TinyStr grammar of all ASCII characters.  For example, if you want `tinystr!("a$b")`, it's not possible to write it without the quotes like `tinystr!(a$b)`.