### PR TITLE
Fix error with undefined symbol "tinystr_macros" at call sites

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -82,10 +82,13 @@ extern crate std;
 #[cfg(all(not(feature = "std"), not(test)))]
 extern crate core as std;
 
-pub mod macros;
+mod macros;
 mod tinystr16;
 mod tinystr4;
 mod tinystr8;
+
+/// Re-export of the low-level tinystr_macros crate, required by the macros.
+pub use tinystr_macros as raw_macros;
 
 #[cfg(any(feature = "std", feature = "alloc"))]
 mod tinystrauto;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -82,7 +82,7 @@ extern crate std;
 #[cfg(all(not(feature = "std"), not(test)))]
 extern crate core as std;
 
-mod macros;
+pub mod macros;
 mod tinystr16;
 mod tinystr4;
 mod tinystr8;

--- a/src/macros.rs
+++ b/src/macros.rs
@@ -1,6 +1,3 @@
-/// Re-export of the low-level tinystr_macros crate.
-pub use tinystr_macros;
-
 /// Macro to create a const TinyStr4, validated with zero runtime cost.
 ///
 /// The argument must be a string literal:
@@ -18,9 +15,7 @@ pub use tinystr_macros;
 #[macro_export]
 macro_rules! tinystr4 {
     ($s:literal) => {
-        unsafe {
-            $crate::TinyStr4::new_unchecked($crate::macros::tinystr_macros::u32_from_bytes!($s))
-        }
+        unsafe { $crate::TinyStr4::new_unchecked($crate::raw_macros::u32_from_bytes!($s)) }
     };
 }
 
@@ -49,9 +44,7 @@ fn test_tinystr4() {
 #[macro_export]
 macro_rules! tinystr8 {
     ($s:literal) => {
-        unsafe {
-            $crate::TinyStr8::new_unchecked($crate::macros::tinystr_macros::u64_from_bytes!($s))
-        }
+        unsafe { $crate::TinyStr8::new_unchecked($crate::raw_macros::u64_from_bytes!($s)) }
     };
 }
 
@@ -80,9 +73,7 @@ fn test_tinystr8() {
 #[macro_export]
 macro_rules! tinystr16 {
     ($s:literal) => {
-        unsafe {
-            $crate::TinyStr16::new_unchecked($crate::macros::tinystr_macros::u128_from_bytes!($s))
-        }
+        unsafe { $crate::TinyStr16::new_unchecked($crate::raw_macros::u128_from_bytes!($s)) }
     };
 }
 

--- a/src/macros.rs
+++ b/src/macros.rs
@@ -1,3 +1,6 @@
+/// Re-export of the low-level tinystr_macros crate.
+pub use tinystr_macros;
+
 /// Macro to create a const TinyStr4, validated with zero runtime cost.
 ///
 /// The argument must be a string literal:
@@ -15,7 +18,9 @@
 #[macro_export]
 macro_rules! tinystr4 {
     ($s:literal) => {
-        unsafe { $crate::TinyStr4::new_unchecked(tinystr_macros::u32_from_bytes!($s)) }
+        unsafe {
+            $crate::TinyStr4::new_unchecked($crate::macros::tinystr_macros::u32_from_bytes!($s))
+        }
     };
 }
 
@@ -44,7 +49,9 @@ fn test_tinystr4() {
 #[macro_export]
 macro_rules! tinystr8 {
     ($s:literal) => {
-        unsafe { $crate::TinyStr8::new_unchecked(tinystr_macros::u64_from_bytes!($s)) }
+        unsafe {
+            $crate::TinyStr8::new_unchecked($crate::macros::tinystr_macros::u64_from_bytes!($s))
+        }
     };
 }
 
@@ -73,7 +80,9 @@ fn test_tinystr8() {
 #[macro_export]
 macro_rules! tinystr16 {
     ($s:literal) => {
-        unsafe { $crate::TinyStr16::new_unchecked(tinystr_macros::u128_from_bytes!($s)) }
+        unsafe {
+            $crate::TinyStr16::new_unchecked($crate::macros::tinystr_macros::u128_from_bytes!($s))
+        }
     };
 }
 


### PR DESCRIPTION
Sorry... one more release.  I think this can be 0.4.1