### PR TITLE
Add repr(transparent)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ name = "tinystr"
 description = """
 A small ASCII-only bounded length string representation.
 """
-version = "0.4.1"
+version = "0.4.2"
 authors = ["Raph Levien <raph.levien@gmail.com>", "Zibi Braniecki <zibi@braniecki.net>", "Shane F. Carr <shane@sffc.xyz>"]
 edition = "2018"
 license = "Apache-2.0/MIT"

--- a/src/tinystr16.rs
+++ b/src/tinystr16.rs
@@ -21,6 +21,7 @@ use crate::Error;
 /// assert!(s1.is_ascii_alphabetic());
 /// ```
 #[derive(Copy, Clone, PartialEq, Eq, Hash)]
+#[repr(transparent)]
 pub struct TinyStr16(NonZeroU128);
 
 impl TinyStr16 {

--- a/src/tinystr4.rs
+++ b/src/tinystr4.rs
@@ -21,6 +21,7 @@ use crate::Error;
 /// assert!(s1.is_ascii_alphabetic());
 /// ```
 #[derive(Copy, Clone, PartialEq, Eq, Hash)]
+#[repr(transparent)]
 pub struct TinyStr4(NonZeroU32);
 
 impl TinyStr4 {

--- a/src/tinystr8.rs
+++ b/src/tinystr8.rs
@@ -21,6 +21,7 @@ use crate::Error;
 /// assert!(s1.is_ascii_alphabetic());
 /// ```
 #[derive(Copy, Clone, PartialEq, Eq, Hash)]
+#[repr(transparent)]
 pub struct TinyStr8(NonZeroU64);
 
 impl TinyStr8 {


### PR DESCRIPTION
With cbindgen master, this makes tinystr types fully cbindgen compatible (except for `TinyStrAuto`)

I would also have added FFI compat functions behind a flag but https://github.com/eqrion/cbindgen/issues/247 prevents us from directly working with slices and I plan to do the scaffolding for that in icu4x.


r? @zbraniecki