### PR TITLE
Implement std::error::Error.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,7 +23,7 @@ criterion = "0.3"
 default = [ "std" ] # Default to using the std
 
 # Use the standard library. Enables TinyStrAuto.
-std = []
+std = [ "tinystr-raw/std" ]
 
 # Use the `alloc` crate. Enables TinyStrAuto. This feature does nothing if std is enabled.
 alloc = []

--- a/raw/Cargo.toml
+++ b/raw/Cargo.toml
@@ -10,3 +10,9 @@ license = "Apache-2.0/MIT"
 repository = "https://github.com/zbraniecki/tinystr"
 keywords = ["string", "str", "small", "tiny", "no_std"]
 categories = ["data-structures"]
+
+[features]
+default = [ "std" ] # Default to using the std
+
+# Use the standard library.
+std = []

--- a/raw/src/error.rs
+++ b/raw/src/error.rs
@@ -1,3 +1,8 @@
+use core::fmt;
+
+#[cfg(feature = "std")]
+use std::error;
+
 /// Enum to store the various types of errors that can cause parsing a TinyStr to fail.
 #[derive(PartialEq, Eq, Debug)]
 pub enum Error {
@@ -7,4 +12,18 @@ pub enum Error {
     InvalidNull,
     /// String contains non-ASCII character(s).
     NonAscii,
+}
+
+impl fmt::Display for Error {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Error::InvalidSize => write!(f, "invalid size"),
+            Error::InvalidNull =>  write!(f, "string is empty"),
+            Error::NonAscii => write!(f, "contains non-ASCII"),
+        }
+    }
+}
+
+#[cfg(feature = "std")]
+impl error::Error for Error {
 }

--- a/tests/main.rs
+++ b/tests/main.rs
@@ -496,6 +496,13 @@ fn tiny16_debug() {
     assert_eq!(format!("{:#?}", s), "\"abcdefghijkl\"");
 }
 
+#[cfg(feature = "std")]
+#[test]
+fn supports_std_error() {
+    let e = "\u{4000}".parse::<TinyStr8>().unwrap_err();
+    let _ : &dyn std::error::Error = &e;
+}
+
 #[cfg(any(feature = "std", feature = "alloc"))]
 #[test]
 fn tinyauto_basic() {


### PR DESCRIPTION
This would mean we can use tinystr's error type with libraries such as [anyhow](https://docs.rs/anyhow/1.0.38/anyhow/).

Closes https://github.com/zbraniecki/tinystr/issues/29