### PR TITLE
Add serde impls

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -18,8 +18,8 @@ before_cache: |
 
 script:
 - cargo clean
-- cargo build
-- cargo test
+- cargo build --features serde
+- cargo test --features serde
 
 
 after_success: |

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,6 +13,7 @@ keywords = ["string", "str", "small", "tiny", "no_std"]
 categories = ["data-structures"]
 
 [dependencies]
+serde = { version = "1.0.123", optional = true }
 tinystr-macros = { version = "0.2", path = "./macros" }
 tinystr-raw = { version = "0.1", path = "./raw" }
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,6 +19,7 @@ tinystr-raw = { version = "0.1", path = "./raw" }
 
 [dev-dependencies]
 criterion = "0.3"
+serde_json = "1.0.59"
 
 [features]
 default = [ "std" ] # Default to using the std
@@ -40,3 +41,7 @@ harness = false
 [[bench]]
 name = "match"
 harness = false
+
+[[test]]
+name = "serde"
+required-features = ["serde"]

--- a/src/tinystr16.rs
+++ b/src/tinystr16.rs
@@ -329,3 +329,28 @@ impl Into<u128> for TinyStr16 {
         self.0.get().to_le()
     }
 }
+
+#[cfg(feature = "serde")]
+impl serde::Serialize for TinyStr16 {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        serializer.serialize_str(self.as_str())
+    }
+}
+
+#[cfg(feature = "serde")]
+impl<'de> serde::Deserialize<'de> for TinyStr16 {
+    fn deserialize<D>(deserializer: D) -> Result<TinyStr16, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        use std::borrow::Cow;
+        use serde::de::Error;
+
+        let x: Cow<'de, str> = serde::Deserialize::deserialize(deserializer)?;
+        x.parse().map_err(|_| Error::custom("TinyStr16 must contain 1-16 non-NUL ASCII bytes"))
+    }
+}
+

--- a/src/tinystr16.rs
+++ b/src/tinystr16.rs
@@ -347,10 +347,11 @@ impl<'de> serde::Deserialize<'de> for TinyStr16 {
         D: serde::Deserializer<'de>,
     {
         use std::borrow::Cow;
-        use serde::de::Error;
+        use serde::de::Error as SerdeError;
+        use std::string::ToString;
 
         let x: Cow<'de, str> = serde::Deserialize::deserialize(deserializer)?;
-        x.parse().map_err(|_| Error::custom("TinyStr16 must contain 1-16 non-NUL ASCII bytes"))
+        x.parse().map_err(|e: Error| SerdeError::custom(e.to_string()))
     }
 }
 

--- a/src/tinystr4.rs
+++ b/src/tinystr4.rs
@@ -311,3 +311,27 @@ impl Into<u32> for TinyStr4 {
         self.0.get().to_le()
     }
 }
+
+#[cfg(feature = "serde")]
+impl serde::Serialize for TinyStr4 {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        serializer.serialize_str(self.as_str())
+    }
+}
+
+#[cfg(feature = "serde")]
+impl<'de> serde::Deserialize<'de> for TinyStr4 {
+    fn deserialize<D>(deserializer: D) -> Result<TinyStr4, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        use std::borrow::Cow;
+        use serde::de::Error;
+
+        let x: Cow<'de, str> = serde::Deserialize::deserialize(deserializer)?;
+        x.parse().map_err(|_| Error::custom("TinyStr4 must contain 1-4 non-NUL ASCII bytes"))
+    }
+}

--- a/src/tinystr4.rs
+++ b/src/tinystr4.rs
@@ -329,9 +329,10 @@ impl<'de> serde::Deserialize<'de> for TinyStr4 {
         D: serde::Deserializer<'de>,
     {
         use std::borrow::Cow;
-        use serde::de::Error;
+        use serde::de::Error as SerdeError;
+        use std::string::ToString;
 
         let x: Cow<'de, str> = serde::Deserialize::deserialize(deserializer)?;
-        x.parse().map_err(|_| Error::custom("TinyStr4 must contain 1-4 non-NUL ASCII bytes"))
+        x.parse().map_err(|e: Error| SerdeError::custom(e.to_string()))
     }
 }

--- a/src/tinystr8.rs
+++ b/src/tinystr8.rs
@@ -321,3 +321,28 @@ impl Into<u64> for TinyStr8 {
         self.0.get().to_le()
     }
 }
+
+#[cfg(feature = "serde")]
+impl serde::Serialize for TinyStr8 {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        serializer.serialize_str(self.as_str())
+    }
+}
+
+#[cfg(feature = "serde")]
+impl<'de> serde::Deserialize<'de> for TinyStr8 {
+    fn deserialize<D>(deserializer: D) -> Result<TinyStr8, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        use std::borrow::Cow;
+        use serde::de::Error;
+
+        let x: Cow<'de, str> = serde::Deserialize::deserialize(deserializer)?;
+        x.parse().map_err(|_| Error::custom("TinyStr8 must contain 1-8 non-NUL ASCII bytes"))
+    }
+}
+

--- a/src/tinystr8.rs
+++ b/src/tinystr8.rs
@@ -339,10 +339,11 @@ impl<'de> serde::Deserialize<'de> for TinyStr8 {
         D: serde::Deserializer<'de>,
     {
         use std::borrow::Cow;
-        use serde::de::Error;
+        use serde::de::Error as SerdeError;
+        use std::string::ToString;
 
         let x: Cow<'de, str> = serde::Deserialize::deserialize(deserializer)?;
-        x.parse().map_err(|_| Error::custom("TinyStr8 must contain 1-8 non-NUL ASCII bytes"))
+        x.parse().map_err(|e: Error| SerdeError::custom(e.to_string()))
     }
 }
 

--- a/src/tinystrauto.rs
+++ b/src/tinystrauto.rs
@@ -78,3 +78,28 @@ impl FromStr for TinyStrAuto {
         }
     }
 }
+
+
+#[cfg(feature = "serde")]
+impl serde::Serialize for TinyStrAuto {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        serializer.serialize_str(&self)
+    }
+}
+
+#[cfg(feature = "serde")]
+impl<'de> serde::Deserialize<'de> for TinyStrAuto {
+    fn deserialize<D>(deserializer: D) -> Result<TinyStrAuto, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        use std::borrow::Cow;
+        use serde::de::Error;
+
+        let x: Cow<'de, str> = serde::Deserialize::deserialize(deserializer)?;
+        x.parse().map_err(|_| Error::custom("TinyStrAuto must contain ASCII bytes"))
+    }
+}

--- a/src/tinystrauto.rs
+++ b/src/tinystrauto.rs
@@ -97,9 +97,10 @@ impl<'de> serde::Deserialize<'de> for TinyStrAuto {
         D: serde::Deserializer<'de>,
     {
         use std::borrow::Cow;
-        use serde::de::Error;
+        use serde::de::Error as SerdeError;
+        use std::string::ToString;
 
         let x: Cow<'de, str> = serde::Deserialize::deserialize(deserializer)?;
-        x.parse().map_err(|_| Error::custom("TinyStrAuto must contain ASCII bytes"))
+        x.parse().map_err(|e: Error| SerdeError::custom(e.to_string()))
     }
 }

--- a/tests/serde.rs
+++ b/tests/serde.rs
@@ -1,0 +1,23 @@
+use tinystr::*;
+use serde_json;
+
+macro_rules! test_roundtrip {
+    ($f:ident, $ty:ident, $val:expr) => {
+        #[test]
+        fn $f() {
+            let tiny: $ty = $val.parse().unwrap();
+            let json_string = serde_json::to_string(&tiny).unwrap();
+            let expected_json = concat!("\"", $val, "\"");
+            assert_eq!(json_string, expected_json);
+            let recover: $ty = serde_json::from_str(&json_string).unwrap();
+            assert_eq!(&*tiny, &*recover);
+        }
+    };
+}
+
+test_roundtrip!(test_roundtrip4_1, TinyStr4, "en");
+test_roundtrip!(test_roundtrip4_2, TinyStr4, "Latn");
+test_roundtrip!(test_roundtrip8, TinyStr8, "calendar");
+test_roundtrip!(test_roundtrip16, TinyStr16, "verylongstring");
+test_roundtrip!(test_roundtripauto_1, TinyStrAuto, "shortstring");
+test_roundtrip!(test_roundtripauto_2, TinyStrAuto, "veryveryverylongstring");


### PR DESCRIPTION
Fixes #32

I didn't add any tests, unsure if we need to test this. It currently just goes through strings, which has the added benefit of making `TinyStr*` serialize to a normal string with serde-json.