### PR TITLE
Add more compact serializers for non human readable serialization

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,6 +20,7 @@ tinystr-raw = { version = "0.1", path = "./raw" }
 [dev-dependencies]
 criterion = "0.3"
 serde_json = "1.0.59"
+bincode = "1.3"
 
 [features]
 default = [ "std" ] # Default to using the std

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -82,6 +82,7 @@ extern crate std;
 #[cfg(all(not(feature = "std"), not(test)))]
 extern crate core as std;
 
+#[macro_use]
 mod macros;
 mod tinystr16;
 mod tinystr4;

--- a/src/tinystr16.rs
+++ b/src/tinystr16.rs
@@ -330,28 +330,4 @@ impl Into<u128> for TinyStr16 {
     }
 }
 
-#[cfg(feature = "serde")]
-impl serde::Serialize for TinyStr16 {
-    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
-    where
-        S: serde::Serializer,
-    {
-        serializer.serialize_str(self.as_str())
-    }
-}
-
-#[cfg(feature = "serde")]
-impl<'de> serde::Deserialize<'de> for TinyStr16 {
-    fn deserialize<D>(deserializer: D) -> Result<TinyStr16, D::Error>
-    where
-        D: serde::Deserializer<'de>,
-    {
-        use std::borrow::Cow;
-        use serde::de::Error as SerdeError;
-        use std::string::ToString;
-
-        let x: Cow<'de, str> = serde::Deserialize::deserialize(deserializer)?;
-        x.parse().map_err(|e: Error| SerdeError::custom(e.to_string()))
-    }
-}
-
+serde_impl!(TinyStr16, u128);

--- a/src/tinystr4.rs
+++ b/src/tinystr4.rs
@@ -312,43 +312,4 @@ impl Into<u32> for TinyStr4 {
     }
 }
 
-#[cfg(feature = "serde")]
-impl serde::Serialize for TinyStr4 {
-    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
-    where
-        S: serde::Serializer,
-    {
-        if serializer.is_human_readable() {
-            serializer.serialize_str(self.as_str())
-        } else {
-            serializer.serialize_u32(self.as_unsigned().to_le())
-        }
-    }
-}
-
-#[cfg(feature = "serde")]
-impl<'de> serde::Deserialize<'de> for TinyStr4 {
-    fn deserialize<D>(deserializer: D) -> Result<TinyStr4, D::Error>
-    where
-        D: serde::Deserializer<'de>,
-    {
-        use std::borrow::Cow;
-        use serde::de::Error as SerdeError;
-        use std::string::ToString;
-
-        if deserializer.is_human_readable() {
-            let x: Cow<'de, str> = serde::Deserialize::deserialize(deserializer)?;
-            x.parse().map_err(|e: Error| SerdeError::custom(e.to_string()))
-        } else {
-            // little-endian
-            let le = serde::Deserialize::deserialize(deserializer)?;
-            let bytes = u32::from_le(le).to_ne_bytes();
-            if let Err(e) = std::str::from_utf8(&bytes) {
-                return Err(SerdeError::custom(e.to_string()))
-            }
-            unsafe {
-                Ok(Self::new_unchecked(le))
-            }
-        }
-    }
-}
+serde_impl!(TinyStr4, u32);

--- a/src/tinystr8.rs
+++ b/src/tinystr8.rs
@@ -322,28 +322,6 @@ impl Into<u64> for TinyStr8 {
     }
 }
 
-#[cfg(feature = "serde")]
-impl serde::Serialize for TinyStr8 {
-    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
-    where
-        S: serde::Serializer,
-    {
-        serializer.serialize_str(self.as_str())
-    }
-}
 
-#[cfg(feature = "serde")]
-impl<'de> serde::Deserialize<'de> for TinyStr8 {
-    fn deserialize<D>(deserializer: D) -> Result<TinyStr8, D::Error>
-    where
-        D: serde::Deserializer<'de>,
-    {
-        use std::borrow::Cow;
-        use serde::de::Error as SerdeError;
-        use std::string::ToString;
 
-        let x: Cow<'de, str> = serde::Deserialize::deserialize(deserializer)?;
-        x.parse().map_err(|e: Error| SerdeError::custom(e.to_string()))
-    }
-}
-
+serde_impl!(TinyStr8, u64);

--- a/tests/serde.rs
+++ b/tests/serde.rs
@@ -11,6 +11,10 @@ macro_rules! test_roundtrip {
             assert_eq!(json_string, expected_json);
             let recover: $ty = serde_json::from_str(&json_string).unwrap();
             assert_eq!(&*tiny, &*recover);
+
+            let bin = bincode::serialize(&tiny).unwrap();
+            let debin: $ty = bincode::deserialize(&bin).unwrap();
+            assert_eq!(&*tiny, &*debin);
         }
     };
 }

--- a/tests/serde.rs
+++ b/tests/serde.rs
@@ -2,7 +2,7 @@ use tinystr::*;
 use serde_json;
 
 macro_rules! test_roundtrip {
-    ($f:ident, $ty:ident, $val:expr) => {
+    ($f:ident, $ty:ident, $val:expr, $bincode:expr) => {
         #[test]
         fn $f() {
             let tiny: $ty = $val.parse().unwrap();
@@ -13,15 +13,16 @@ macro_rules! test_roundtrip {
             assert_eq!(&*tiny, &*recover);
 
             let bin = bincode::serialize(&tiny).unwrap();
+            assert_eq!(bin, $bincode);
             let debin: $ty = bincode::deserialize(&bin).unwrap();
             assert_eq!(&*tiny, &*debin);
         }
     };
 }
 
-test_roundtrip!(test_roundtrip4_1, TinyStr4, "en");
-test_roundtrip!(test_roundtrip4_2, TinyStr4, "Latn");
-test_roundtrip!(test_roundtrip8, TinyStr8, "calendar");
-test_roundtrip!(test_roundtrip16, TinyStr16, "verylongstring");
-test_roundtrip!(test_roundtripauto_1, TinyStrAuto, "shortstring");
-test_roundtrip!(test_roundtripauto_2, TinyStrAuto, "veryveryverylongstring");
+test_roundtrip!(test_roundtrip4_1, TinyStr4, "en", [101, 110, 0, 0]);
+test_roundtrip!(test_roundtrip4_2, TinyStr4, "Latn", [76, 97, 116, 110]);
+test_roundtrip!(test_roundtrip8, TinyStr8, "calendar", [99, 97, 108, 101, 110, 100, 97, 114]);
+test_roundtrip!(test_roundtrip16, TinyStr16, "verylongstring", [118, 101, 114, 121, 108, 111, 110, 103, 115, 116, 114, 105, 110, 103, 0, 0]);
+test_roundtrip!(test_roundtripauto_1, TinyStrAuto, "shortstring", [11, 0, 0, 0, 0, 0, 0, 0, 115, 104, 111, 114, 116, 115, 116, 114, 105, 110, 103]);
+test_roundtrip!(test_roundtripauto_2, TinyStrAuto, "veryveryverylongstring", [22, 0, 0, 0, 0, 0, 0, 0, 118, 101, 114, 121, 118, 101, 114, 121, 118, 101, 114, 121, 108, 111, 110, 103, 115, 116, 114, 105, 110, 103]);


### PR DESCRIPTION
This does not change how TinyStrAuto serializes because there would be a bunch of overhead in making it work there. I tried, and realized it would basically be slower depending on how I use the serialization infrastructure, for not much gain.