### PR TITLE
Inline one-line perf sensitive traits

### DIFF
--- a/src/tinystr16.rs
+++ b/src/tinystr16.rs
@@ -314,7 +314,7 @@ impl PartialOrd for TinyStr16 {
 impl Ord for TinyStr16 {
     #[inline(always)]
     fn cmp(&self, other: &Self) -> Ordering {
-        self.0.get().to_be().cmp(&other.0.get().to_be())
+        self.0.get().to_le().cmp(&other.0.get().to_le()).reverse()
     }
 }
 

--- a/src/tinystr16.rs
+++ b/src/tinystr16.rs
@@ -270,6 +270,7 @@ impl TinyStr16 {
 }
 
 impl fmt::Display for TinyStr16 {
+    #[inline(always)]
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{}", self.deref())
     }
@@ -297,18 +298,21 @@ impl Deref for TinyStr16 {
 }
 
 impl PartialEq<&str> for TinyStr16 {
+    #[inline(always)]
     fn eq(&self, other: &&str) -> bool {
         self.deref() == *other
     }
 }
 
 impl PartialOrd for TinyStr16 {
+    #[inline(always)]
     fn partial_cmp(&self, other: &Self) -> Option<Ordering> {
         Some(self.cmp(other))
     }
 }
 
 impl Ord for TinyStr16 {
+    #[inline(always)]
     fn cmp(&self, other: &Self) -> Ordering {
         self.0.get().to_be().cmp(&other.0.get().to_be())
     }

--- a/src/tinystr4.rs
+++ b/src/tinystr4.rs
@@ -296,7 +296,7 @@ impl PartialOrd for TinyStr4 {
 impl Ord for TinyStr4 {
     #[inline(always)]
     fn cmp(&self, other: &Self) -> Ordering {
-        self.0.get().to_be().cmp(&other.0.get().to_be())
+        self.0.get().to_le().cmp(&other.0.get().to_le()).reverse()
     }
 }
 

--- a/src/tinystr4.rs
+++ b/src/tinystr4.rs
@@ -252,6 +252,7 @@ impl TinyStr4 {
 }
 
 impl fmt::Display for TinyStr4 {
+    #[inline(always)]
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{}", self.deref())
     }
@@ -279,18 +280,21 @@ impl Deref for TinyStr4 {
 }
 
 impl PartialEq<&str> for TinyStr4 {
+    #[inline(always)]
     fn eq(&self, other: &&str) -> bool {
         self.deref() == *other
     }
 }
 
 impl PartialOrd for TinyStr4 {
+    #[inline(always)]
     fn partial_cmp(&self, other: &Self) -> Option<Ordering> {
         Some(self.cmp(other))
     }
 }
 
 impl Ord for TinyStr4 {
+    #[inline(always)]
     fn cmp(&self, other: &Self) -> Ordering {
         self.0.get().to_be().cmp(&other.0.get().to_be())
     }

--- a/src/tinystr8.rs
+++ b/src/tinystr8.rs
@@ -263,6 +263,7 @@ impl TinyStr8 {
 }
 
 impl fmt::Display for TinyStr8 {
+    #[inline(always)]
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{}", self.deref())
     }
@@ -290,18 +291,21 @@ impl Deref for TinyStr8 {
 }
 
 impl PartialEq<&str> for TinyStr8 {
+    #[inline(always)]
     fn eq(&self, other: &&str) -> bool {
         self.deref() == *other
     }
 }
 
 impl PartialOrd for TinyStr8 {
+    #[inline(always)]
     fn partial_cmp(&self, other: &Self) -> Option<Ordering> {
         Some(self.cmp(other))
     }
 }
 
 impl Ord for TinyStr8 {
+    #[inline(always)]
     fn cmp(&self, other: &Self) -> Ordering {
         self.0.get().to_be().cmp(&other.0.get().to_be())
     }

--- a/src/tinystr8.rs
+++ b/src/tinystr8.rs
@@ -307,7 +307,7 @@ impl PartialOrd for TinyStr8 {
 impl Ord for TinyStr8 {
     #[inline(always)]
     fn cmp(&self, other: &Self) -> Ordering {
-        self.0.get().to_be().cmp(&other.0.get().to_be())
+        self.0.get().to_le().cmp(&other.0.get().to_le()).reverse()
     }
 }
 

--- a/src/tinystrauto.rs
+++ b/src/tinystrauto.rs
@@ -64,21 +64,13 @@ impl PartialEq<&str> for TinyStrAuto {
 impl FromStr for TinyStrAuto {
     type Err = Error;
 
-    #[inline(always)]
     fn from_str(text: &str) -> Result<Self, Self::Err> {
         if text.len() <= 16 {
-            match TinyStr16::from_str(text) {
-                Ok(result) => Ok(TinyStrAuto::Tiny(result)),
-                Err(err) => Err(err),
-            }
+            TinyStr16::from_str(text).map(TinyStrAuto::Tiny)
+        } else if text.is_ascii() {
+            Ok(TinyStrAuto::Heap(text.into()))
         } else {
-            if !text.is_ascii() {
-                return Err(Error::NonAscii);
-            }
-            match String::from_str(text) {
-                Ok(result) => Ok(TinyStrAuto::Heap(result)),
-                Err(_) => unreachable!(),
-            }
+            Err(Error::NonAscii)
         }
     }
 }

--- a/src/tinystrauto.rs
+++ b/src/tinystrauto.rs
@@ -35,6 +35,7 @@ pub enum TinyStrAuto {
 }
 
 impl fmt::Display for TinyStrAuto {
+    #[inline(always)]
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         self.deref().fmt(f)
     }
@@ -43,6 +44,7 @@ impl fmt::Display for TinyStrAuto {
 impl Deref for TinyStrAuto {
     type Target = str;
 
+    #[inline(always)]
     fn deref(&self) -> &str {
         use TinyStrAuto::*;
         match self {
@@ -53,6 +55,7 @@ impl Deref for TinyStrAuto {
 }
 
 impl PartialEq<&str> for TinyStrAuto {
+    #[inline(always)]
     fn eq(&self, other: &&str) -> bool {
         self.deref() == *other
     }
@@ -61,6 +64,7 @@ impl PartialEq<&str> for TinyStrAuto {
 impl FromStr for TinyStrAuto {
     type Err = Error;
 
+    #[inline(always)]
     fn from_str(text: &str) -> Result<Self, Self::Err> {
         if text.len() <= 16 {
             match TinyStr16::from_str(text) {


### PR DESCRIPTION
Fixes #39.

Inlining one-liners closes the gap to `u32/u64` on the instruction count. What's left is `to_be` being not a no-op on `le` platforms.