### PR TITLE
Hand-roll big-endian deref implementation

### DIFF
--- a/src/tinystr16.rs
+++ b/src/tinystr16.rs
@@ -320,9 +320,11 @@ impl Deref for TinyStr16 {
 
     #[inline(always)]
     fn deref(&self) -> &str {
-        // Again, could use #cfg to hand-roll a big-endian implementation.
-        let word = self.0.get().to_le();
+        let word = self.0.get();
+        #[cfg(target_endian = "little")]
         let len = (16 - word.leading_zeros() / 8) as usize;
+        #[cfg(target_endian = "big")]
+        let len = (16 - word.trailing_zeros() / 8) as usize;
         unsafe {
             let slice = core::slice::from_raw_parts(&self.0 as *const _ as *const u8, len);
             std::str::from_utf8_unchecked(slice)

--- a/src/tinystr4.rs
+++ b/src/tinystr4.rs
@@ -302,9 +302,11 @@ impl Deref for TinyStr4 {
 
     #[inline(always)]
     fn deref(&self) -> &str {
-        // Again, could use #cfg to hand-roll a big-endian implementation.
-        let word = self.0.get().to_le();
+        let word = self.0.get();
+        #[cfg(target_endian = "little")]
         let len = (4 - word.leading_zeros() / 8) as usize;
+        #[cfg(target_endian = "big")]
+        let len = (4 - word.trailing_zeros() / 8) as usize;
         unsafe {
             let slice = core::slice::from_raw_parts(&self.0 as *const _ as *const u8, len);
             std::str::from_utf8_unchecked(slice)

--- a/src/tinystr8.rs
+++ b/src/tinystr8.rs
@@ -313,9 +313,11 @@ impl Deref for TinyStr8 {
 
     #[inline(always)]
     fn deref(&self) -> &str {
-        // Again, could use #cfg to hand-roll a big-endian implementation.
-        let word = self.0.get().to_le();
+        let word = self.0.get();
+        #[cfg(target_endian = "little")]
         let len = (8 - word.leading_zeros() / 8) as usize;
+        #[cfg(target_endian = "big")]
+        let len = (8 - word.trailing_zeros() / 8) as usize;
         unsafe {
             let slice = core::slice::from_raw_parts(&self.0 as *const _ as *const u8, len);
             std::str::from_utf8_unchecked(slice)


### PR DESCRIPTION
Use the count trailing zeros method on big-endian architectures instead
of byte-swapping the integer to little-endian. This passes all tests
when ran with `miri test --target mips64-unknown-linux-gnuabi64`.

I am unable to check if this improves performance because I do not own
a big-endian machine to benchmark with. Oddly on [mips](https://rust.godbolt.org/z/9bE3naex9) the trailing_zeros
method produces more assembly because mips does not have a count trailing zeros instruction
but it this seems like a implementation detail that can be dealt with by the codegen backend.