### PR TITLE
Fix no_std for serde

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,16 +16,18 @@ repository = "https://github.com/zbraniecki/tinystr"
 readme = "README.md"
 keywords = ["string", "str", "small", "tiny", "no_std"]
 categories = ["data-structures"]
+# needed to avoid dev-dependency features unifying
+resolver = "2"
 
 [dependencies]
-serde = { version = "1.0.123", optional = true }
+serde = { version = "1.0.123", optional = true, default-features = false, features = ["alloc"] }
 tinystr-macros = { version = "0.2", path = "./macros" }
 tinystr-raw = { version = "0.1.2", path = "./raw" }
 zerovec = {version = "0.2.0", optional = true }
 
 [dev-dependencies]
 criterion = "0.3"
-serde_json = "1.0"
+serde_json = { version = "1.0", default-features = false, features = ["alloc"] }
 bincode = "1.3"
 iai = "0.1"
 rand = "0.8"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -82,6 +82,9 @@ extern crate std;
 #[cfg(all(not(feature = "std"), not(test)))]
 extern crate core as std;
 
+#[cfg(feature = "serde")]
+extern crate alloc;
+
 #[macro_use]
 mod macros;
 mod tinystr16;

--- a/src/macros.rs
+++ b/src/macros.rs
@@ -101,8 +101,8 @@ macro_rules! serde_impl {
                 D: serde::Deserializer<'de>,
             {
                 use serde::de::Error as SerdeError;
-                use std::borrow::Cow;
-                use std::string::ToString;
+                use alloc::borrow::Cow;
+                use alloc::string::ToString;
 
                 if deserializer.is_human_readable() {
                     let x: Cow<'de, str> = serde::Deserialize::deserialize(deserializer)?;


### PR DESCRIPTION
This switches us to the new resolver

The resolver option exists since [Rust 1.51](https://blog.rust-lang.org/2021/03/25/Rust-1.51.0.html)