### PR TITLE
Support formatting parameters in Display implementations and added tests

### DIFF
--- a/src/tinystr16.rs
+++ b/src/tinystr16.rs
@@ -305,7 +305,7 @@ impl TinyStr16 {
 impl fmt::Display for TinyStr16 {
     #[inline(always)]
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.deref())
+        self.deref().fmt(f)
     }
 }
 

--- a/src/tinystr4.rs
+++ b/src/tinystr4.rs
@@ -287,7 +287,7 @@ impl TinyStr4 {
 impl fmt::Display for TinyStr4 {
     #[inline(always)]
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.deref())
+        self.deref().fmt(f)
     }
 }
 

--- a/src/tinystr8.rs
+++ b/src/tinystr8.rs
@@ -298,7 +298,7 @@ impl TinyStr8 {
 impl fmt::Display for TinyStr8 {
     #[inline(always)]
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.deref())
+        self.deref().fmt(f)
     }
 }
 

--- a/tests/main.rs
+++ b/tests/main.rs
@@ -208,6 +208,7 @@ fn tiny4_display() {
     write!(result, "{}", s).unwrap();
     assert_eq!(result, "abcd");
     assert_eq!(format!("{}", s), "abcd");
+    assert_eq!(format!("{:>8}", s), format!("{:>8}", result));
 }
 
 #[test]
@@ -388,6 +389,7 @@ fn tiny8_display() {
     write!(result, "{}", s).unwrap();
     assert_eq!(result, "abcdef");
     assert_eq!(format!("{}", s), "abcdef");
+    assert_eq!(format!("{:>8}", s), format!("{:>8}", result));
 }
 
 #[test]
@@ -586,6 +588,7 @@ fn tiny16_display() {
     write!(result, "{}", s).unwrap();
     assert_eq!(result, "abcdefghijkl");
     assert_eq!(format!("{}", s), "abcdefghijkl");
+    assert_eq!(format!("{:>14}", s), format!("{:>14}", result));
 }
 
 #[test]


### PR DESCRIPTION
I've added support for formatting parameters in the Display implementations of `TinyStr4`, `TinyStr8`, `TinyStr16` -- the same as `TinyStrAuto`.